### PR TITLE
Fix get values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-const axios = require("axios");
 const dayjs = require("dayjs");
 
 const getUF = require("./indicators/getUF");
@@ -8,40 +7,55 @@ const getUTM = require("./indicators/getUTM");
 const getIPC = require("./indicators/getIPC");
 
 /**
- * It fetches data from the Central Bank of Chile's API, and returns a single object with all the data
+ * It fetches data from the Central Bank of Chile's API and returns it in a single object
  * @returns An object with the following structure:
  * {
  *     UF: {
- *         date: "2020-04-01",
- *         value: 28.8
+ *         date: "2020-09-01",
+ *         value: 0.0027
  *     },
  *     USD: {
- *         date: "2020-04-01",
- *         value: 755.5
+ *         date: "2020-09-01",
+ *         value: 0.0013
  *     },
  *     EUR: {
- *         date: "2020-04-01",
+ *         date: "2020-09-01",
  */
 const main = async () => {
     const sevenDaysAgo = dayjs().subtract(7, "day").format("YYYY/MM/[dias]/DD");
-    const lastMonth = dayjs().subtract(1, "month").format("YYYY/MM");
-    const twoMonthBefore = dayjs().subtract(2, "month").format("YYYY/MM");
+    const twoMonthAgo = dayjs().subtract(2, "month").format("YYYY/MM");
+    const threeMonthAgo = dayjs().subtract(3, "month").format("YYYY/MM");
 
-    const [ufData, usdData, eurData, utmData, ipcData] = await Promise.all([
-        getUF(sevenDaysAgo),
-        getUSD(sevenDaysAgo),
-        getEUR(sevenDaysAgo),
-        getUTM(lastMonth),
-        getIPC(twoMonthBefore),
-    ]);
+    const [ufData, usdData, eurData, utmData, ipcData] =
+        await Promise.allSettled([
+            getUF(sevenDaysAgo),
+            getUSD(sevenDaysAgo),
+            getEUR(sevenDaysAgo),
+            getUTM(twoMonthAgo),
+            getIPC(threeMonthAgo),
+        ]);
 
-    const mergedData = {
-        UF: ufData,
-        USD: usdData,
-        EUR: eurData,
-        UTM: utmData,
-        IPC: ipcData,
-    };
+    const mergedData = {};
+
+    if (ufData.status === "fulfilled") {
+        mergedData.UF = ufData.value;
+    }
+
+    if (usdData.status === "fulfilled") {
+        mergedData.USD = usdData.value;
+    }
+
+    if (eurData.status === "fulfilled") {
+        mergedData.EUR = eurData.value;
+    }
+
+    if (utmData.status === "fulfilled") {
+        mergedData.UTM = utmData.value;
+    }
+
+    if (ipcData.status === "fulfilled") {
+        mergedData.IPC = ipcData.value;
+    }
 
     return mergedData;
 };


### PR DESCRIPTION
## Bug description
If a value was not updated in the CMF, then it threw an error and did not load values.

## Main cause
If it did not find values, then it brought error 500.

## Solution
The functions are called with the `allSettled` method and, furthermore, the UTM will look back two months in advance, so that it always has values and IPC will look back three month ago. [Documentation](https://api.cmfchile.cl/documentacion/UTM.html).